### PR TITLE
Feature: A20 Line Check @Bootloader

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,5 @@
+target remote localhost:1234
+br *0x7c00
+lay n
+c
+

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ bootblock: always
 # QEMU
 #
 qemu: cosa
-	qemu-system-i386 -nographic -drive file=$(DIR_BUILD)/$(IMG_NAME).img,index=0,media=disk,format=raw -smp 1 -m 512
+	qemu-system-i386 -nographic -drive file=$(DIR_BUILD)/$(IMG_NAME).img,index=0,media=disk,format=raw -smp 1 -m 512 -S -s
 
 #
 # Misc File Manipulation Methods

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ all: bootblock cosa
 cosa: bootblock
 	dd if=/dev/zero of=$(DIR_BUILD)/$(IMG_NAME).img count=10000
 	dd if=$(DIR_BOOTBLOCK)/bootblock of=$(DIR_BUILD)/$(IMG_NAME).img conv=notrunc seek=0
-	cp ./scripts/cosa-qemu.sh ./build
 
 bootblock: always
 		$(CC) $(CCFLAGS) -fno-pic -nostdinc -I$(SRC_BOOTBLOCK)/. -c $(SRC_BOOTBLOCK)/boot.S 

--- a/bootblock/boot.S
+++ b/bootblock/boot.S
@@ -1,21 +1,68 @@
+#include "macros.h"
+
 .code16
 .globl start
 start:
+	cli
+
 	// set the registers to zero
 	xorw %ax, %ax
+	movw %ax, %bx
 	movw %ax, %es
-	movw %ax, %cs
-	movw %ax, %ds
 	movw %ax, %fs
+	movw %ax, %di
+	movw %ax, %si
 
-	// we now test the a20 line
-	// 1. set the segment registers for memory access
-	movw $510, %di	
+	// attempt to force a warp-around to check 
+	// for the A20 line state.
+	// make a write to the magic number location
+	// which is at physical address: 510 offset from 0x7c00!	
 
-	// move into memory the magic value
-	movw %es:(%di), %ax
+pre_registers_a20:
+	// we prepare the index and segement registers
+	// for the a20 check.
+	// es: 0x0000 		di: 510
+	// fs: 0xFFFF			si: ???
+	// sets fs to 0xffff
+	not %bx
+	movw %bx, %fs
+	
+	// sets the indices 
+	movw $0x7b00, %di
+	movw $0x7b16, %si
+	
+	jmp write_pre_a20_check
 
-	// 
+write_pre_a20_check:
+	// writes to the es:di mem location the magic value
+	movw $A20_MAGIC, %es:(%di)
+	
+	// we want to clear the cx register 
+	// just to be sure.
+	movw %ax, %cx	
+
+	jmp check_a20
+
+check_a20:
+	// we begin by checking the magic value
+	// which *should* be at location 0x7b00
+	// when the a20 line is dead.
+	movw %fs:(%si), %cx
+	movw $A20_MAGIC, %bx
+	cmp %bx, %cx
+	jne post_a20_on
+
+post_a20_off:
+		jmp main
+	
+post_a20_on:
+	// we are going to write to the location at
+	// fs:si to prove that a20 is actually on!
+	movw $A20_MAGIC_PROOF, %fs:(%si)	
+
+main:
+	jmp main	
+
 // sets the padding for the magic MBR
 .space 510-(.-start)
 .word 0xaa55

--- a/bootblock/boot.S
+++ b/bootblock/boot.S
@@ -1,23 +1,9 @@
 .code16
 .globl start
 start:
-	cli
-	
 	// set the registers to zero
 	xorw %ax, %ax
-	movw %ax, %ds
-	movw %ax, %es
-	movw %ax, %ss
 
-	// set the x at the video buffer
-	mov $0xb800, %ax
-	mov %ax, %es
-
-	movw $0x44, %es:0x0
-	
-	loop:
-		jmp loop
-	hlt
-
+// sets the padding for the magic MBR
 .space 510-(.-start)
 .word 0xaa55

--- a/bootblock/boot.S
+++ b/bootblock/boot.S
@@ -3,7 +3,19 @@
 start:
 	// set the registers to zero
 	xorw %ax, %ax
+	movw %ax, %es
+	movw %ax, %cs
+	movw %ax, %ds
+	movw %ax, %fs
 
+	// we now test the a20 line
+	// 1. set the segment registers for memory access
+	movw $510, %di	
+
+	// move into memory the magic value
+	movw %es:(%di), %ax
+
+	// 
 // sets the padding for the magic MBR
 .space 510-(.-start)
 .word 0xaa55

--- a/bootblock/macros.h
+++ b/bootblock/macros.h
@@ -1,0 +1,7 @@
+#ifndef _BOOTBLOCK_h_
+#define _BOOTBLOCK_h_
+
+#define A20_MAGIC 0xabcd
+#define A20_MAGIC_PROOF 0xcdab
+
+#endif

--- a/scripts/cosa-qemu.sh
+++ b/scripts/cosa-qemu.sh
@@ -12,4 +12,4 @@ while getopts "g" flag; do
     esac
 done
 
-qemu-system-i386 -nographic -drive file=build/cosa.img,index=0,media=disk,format=raw -smp 1 -m 512 $gdbflags
+qemu-system-i386 -nographic -drive file="build/cosa.img",index=0,media=disk,format=raw -smp 1 -m 512 $gdbflags


### PR DESCRIPTION
# Description

Added a feature to the bootloader that allows for handling a dead A20 line. This is due to legacy issues when using the legacy BIOS to boot into the kernel.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by probing memory locations using gdb (`make qemu` in the source directory to run this). I was able to confirm in 16bit real-mode that a write to 0000:7b00 isn't reflected at ffff:(7b00+0x10). If the A20 line was dead, we would be able to see changes to the first segment mov would be reflected in the second segmented address access. 

I also added a secondary write that I was able to confirm using both qemu's `xp` command and gdb's `x /x` command (placing the respective address).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules